### PR TITLE
Create Make not editable edited by script

### DIFF
--- a/Make not editable edited by script
+++ b/Make not editable edited by script
@@ -1,0 +1,7 @@
+var gr = new GlideRecord('kb_knowledge');
+gr.addEncodedQuery('numberSTARTSWITHKB0043839');//Suppose is the KB article number, I want to update it's parent field. which is readable
+gr.query();
+if(gr.next()){
+gr.parent = '32ed3ec5db61c8544a824531ba9619eb';//This is the 32 digits sys_id of the Knowledge article which I want to update in parent field.
+gr.update();
+}


### PR DESCRIPTION
Requirement: To update the Knowledge article parent field. 
Challenges: If you have a readable field. It's difficult to update it. We are not able to edit the record by opening the form and list view.
Overcome: To overcome this problem, we can use this script to update the parent field.